### PR TITLE
Add publications section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ __pycache__
 # Node modules and npm cache directory
 node_modules/
 .npm/
+
+# Visual Studio Code
+.vscode
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ To understand upcoming work, view our [roadmap for 2025/6](https://docs.google.c
   - [Dashboards](#dashboards)
   - [Highlights](#highlights)
   - [Topics](#topics)
+  - [Publications](#publications)
   - [News](#news)
   - [Events](#events)
   - [New content](#new-content)
+  - [Remove content](#remove-content)
+    - [Disabled temporarily](#disabled-temporarily)
+    - [Delete permenantly](#delete-permenantly)
 - [Themes](#themes)
   - [Layout](#layout)
   - [Update theme](#update-theme)
@@ -166,6 +170,30 @@ The above command will create a new file in the `content/topics` directory. Fill
 
 **Note:** In order to include the a dashboard or highlight under a specific topic, you must list that topic in the front matter of the corresponding content.
 
+### Publications
+
+Publications page included in the PPN theme uses `Europe PMC API` to fetch and display 10 recent publications for `query_list` defined in the config file `hugo.yaml`. The configurations related to this page should be set in `params.publications` section of the config file. For instance, if you see the config file in the repo
+
+```yaml
+params:
+   publications:
+      country: "Sweden"
+      # It is important to use "" (double quotes) within the query string
+      query_list:
+         covid-19: 'ABSTRACT:("sars-cov-2" OR "covid-19")'
+         influenza: 'ABSTRACT:"influenza"'
+      # Optional setting
+      category_display: "list"
+```
+
+`country` - Should be the same country as the node, only publications affiliated with the specified country is retrieved.
+
+`query_list` - List of _keyword_ and _query string_ of users choice, the _keyword_ is used for category (navigation) in the rendered page and _query string_ is used by the _Europe PMC API_ to fetch publications. Mentioned above _(covid-19 and influenza)_ is just an example, the user should decide relavant keywords/categories and their query string.
+
+**NOTE:** While setting the query string for a keyword in should be enclosed within `''` (single quotes), because the query string itself should contain `""` (double quotes) for word matching. To get deep understanding of the query syntax and build efficient query, checkout Europe PMC [documentation](https://europepmc.org/help).
+
+`category_display` - An optional setting to define how the category links are displayed in the rendered page. If this parameter is set to _"dropdown"_, the categories are displayed as a dropdown menu. And if the parameter is set to anything else or if the parameter doesn't exist in the config file, the categories are displayed as list links on the side.
+
 ### News
 
 News articles are updates regarding the portal, and perhaps other relevant information/news from the area in which the node is based. For example, the Swedish node also posts news about outbreaks in Sweden. To add a news article, run the following command from root of the repository on your computer. The `<desired file name>` in the command is the new file you want (but without spaces).
@@ -274,54 +302,88 @@ You can create a section by creating a folder (and index file within it). Adding
 
    **Note:** Here, `services` is used instead of `navbar_main` as the `menu` key. In all cases, you should use the `identifier` used for the section index file (see step 1) as the key.
 
+
+### Remove content
+
+The content included in this toolbox are just suggestions, so it is perfectly resonable to hide/remove the suggested default pages or sections. There are two ways to do it as mentioned below.
+
+#### Disabled temporarily
+
+If you want to not include a page/section temporarily from the website, but you wanna keep the files in the repo for future purpose you can use `ignoreFiles` in the config settings. With this setting you can specify the folder or file name to not include in the built website, below you can find some examples settings.
+
+- To not include the whole `highlights` section
+
+```yaml
+ignoreFiles:
+   - highlights
+```
+
+- To not include only demo highlight 2
+```yaml
+ignoreFiles:
+   - demo2_highlight.md
+```
+
+- To not include the multiple sections (`news` and `events`) and pages (demo highlight 2)
+```yaml
+ignoreFiles:
+   - news
+   - events
+   - demo2_highlight.md
+```
+
+#### Delete permenantly
+
+To remove a default section or page permanatly, the respective folder or file can just be deleted normally.
+
 ## Themes
 
 This repository uses [pathogens portal node theme](https://github.com/ScilifelabDataCentre/node-pathogens-portal-theme). It defines the layout and design for displaying content on the website.
 
 ### Layout
 
-If you want to create a new layout or replace the exisitng layouts, create a `layouts` directory and start filling it with your own layouts for each page. For example,
+#### New layout
 
-- A `layout/dashboards/list.html` file would determine how the `content/dashboards/_index.md` file is displayed
-- A `layout/dashboards/single.html` file will determine how the `content/dashboards/internal_dash.md`, and all other dashboard pages, are displayed
+If you want to create a new layout, create a `layouts` directory and start filling it with your own layouts for each section/page. For example, lets imagine there a content section called _articles_ and to create your own layout you will create a directory `layouts/articles` and in that directory you can have two files
+
+- `list.html` - file would determine how the `content/articles/_index.md` file is displayed
+- `single.html` - file will determine how the `content/articales/<individual files>.md` files are displayed
 
 In order to read more about options with `hugo` layouts, please see the [Hugo documentation](https://gohugo.io/templates/)
+
+#### Edit default
+
+If you want edit/tweak a layout that is included in the PPN theme, you can just copy the respective folders from the theme layout to the project's layout. For example, if you wanna change the _dashboards_ layout included in the theme 
+
+```
+cp -r themes/node-pathogens-portal-theme/layouts/dashboards layouts/
+```
+
+**NOTE:** You create your own _dashboards_ layout using the _"new layout"_ approach mentioned above, but copying the layout from theme will save a lot of time if the intended edit is not a minor change. **Also avoid directly modifying the files in themes directory**.
 
 ### Update theme
 
 The [pathogens portal node theme](https://github.com/ScilifelabDataCentre/node-pathogens-portal-theme) might be updated from time to time. If you would like to pull the latest changes for your own site, follow the steps below.
 
-1. Open a terminal and go to themes folder in the `hugo` project
+1. Open a terminal and go into the repository root
 
    ```
-   cd <hugo project path>/themes/node-pathogens-portal-theme
+   cd <path to repository>
    ```
 
-2. Once in the `themes/node-pathogens-portal-theme`, run
+2. Run the submodule update command, this will pull all latest changes in the theme
 
    ```
-   git checkout main
+   git submodule update --remote
    ```
 
-3. Pull the latest changes
-
-   ```
-   git pull origin main
-   ```
-
-4. Go back to project root again
-
-   ```
-   cd ../..
-   ```
-
-5. Add this change so that the lastest commit of the theme is linked to the hugo repo
+3. Add this change so that the lastest commit of the theme is linked to this repository
 
    ```
    git add themes/node-pathogens-portal-theme
    ```
 
-6. Commit the change and push to remote as usual
+4. Commit the change and push to remote as usual
 
    ```
    git commit -m "Updated the theme"

--- a/README.md
+++ b/README.md
@@ -357,9 +357,17 @@ In order to read more about options with `hugo` layouts, please see the [Hugo do
 
 If you want to edit a layout that is included in the PPN theme, you can copy the respective folders from the theme layout in to the project's layout. For example, if you want to change the _dashboards_ layout included in the PPN theme:
 
-```
-cp -r themes/node-pathogens-portal-theme/layouts/dashboards layouts/
-```
+1. Open a terminal and go into the repository root
+
+   ```
+   cd <path to repository>
+   ```
+
+2. Copy the desired layout from themes (_dashboard_ for example)
+
+   ```
+   cp -r themes/node-pathogens-portal-theme/layouts/dashboards layouts/
+   ```
 
 **NOTE:** You can create your own _dashboards_ layout using the _"new layout"_ approach mentioned above. However, copying the layout from PPN theme will save a lot of time if major changes are needed. **Please avoid directly modifying the files in themes directory**.
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To understand upcoming work, view our [roadmap for 2025/6](https://docs.google.c
   - [Publications](#publications)
   - [News](#news)
   - [Events](#events)
-  - [New content](#new-content)
-  - [Remove content](#remove-content)
+  - [How to add New content](#how-to-add-new-content)
+  - [How to remove default content](#how-to-remove-default-content)
     - [Disabled temporarily](#disabled-temporarily)
     - [Delete permenantly](#delete-permenantly)
 - [Themes](#themes)
@@ -168,11 +168,13 @@ hugo new content topics/<desired file name>.md
 
 The above command will create a new file in the `content/topics` directory. Fill in the front end matter (i.e. the variables at the top of the file and between the two `---`) with appropriate value, and start writing your content.
 
-**Note:** In order to include the a dashboard or highlight under a specific topic, you must list that topic in the front matter of the corresponding content.
+**Note:** In order to include a dashboard or highlight under a specific topic, you must list that topic in the front matter of the corresponding content.
 
 ### Publications
 
-Publications page included in the PPN theme uses `Europe PMC API` to fetch and display 10 recent publications for `query_list` defined in the config file `hugo.yaml`. The configurations related to this page should be set in `params.publications` section of the config file. For instance, if you see the config file in the repo
+The publications page included in the PPN theme uses the `Europe PMC API` to fetch and display relevant publications. In particular, it shows 10 recent publications for each of the pathogens given in `query_list`. The publications will all involve a researcher affiliated with a specified nation, which should be specified under `country`.
+
+The configurations related to this page should be set in the `params.publications` section of the `hugo.yaml` config file. See below for an example:
 
 ```yaml
 params:
@@ -186,13 +188,13 @@ params:
       category_display: "list"
 ```
 
-`country` - Should be the same country as the node, only publications affiliated with the specified country is retrieved.
+`country` - Should be set as the relevant nation for the node. Here, the country is set to 'Sweden', so publications including researchers affiliated with Swedish institutions will be shown.
 
-`query_list` - List of _keyword_ and _query string_ of users choice, the _keyword_ is used for category (navigation) in the rendered page and _query string_ is used by the _Europe PMC API_ to fetch publications. Mentioned above _(covid-19 and influenza)_ is just an example, the user should decide relavant keywords/categories and their query string.
+`query_list` - List of _keyword_ and _query string_ to define the pathogens that publications should related to, and what search should be used to identify relevant publications. The _keyword_ is used for category (navigation) in the rendered page. This means that it will be what shows in the filter on the page in the PPN. The _query string_ is used by the _Europe PMC API_ to search publications for relevant keywords. For example, here,  the abstracts of papers are searched for the terms 'SARS-CoV-2' OR 'COVID-19' to identify papers related to COVID-19.  Any pathogen can be listed here, at the users discretion.
 
-**NOTE:** While setting the query string for a keyword in should be enclosed within `''` (single quotes), because the query string itself should contain `""` (double quotes) for word matching. To get deep understanding of the query syntax and build efficient query, checkout Europe PMC [documentation](https://europepmc.org/help).
+**NOTE:** When setting the query string for a keyword, it should be enclosed within `''` (single quotes), because the query string itself should contain `""` (double quotes) for word matching. To get deep understanding of the query syntax and build efficient query, see the Europe PMC [documentation](https://europepmc.org/help).
 
-`category_display` - An optional setting to define how the category links are displayed in the rendered page. If this parameter is set to _"dropdown"_, the categories are displayed as a dropdown menu. And if the parameter is set to anything else or if the parameter doesn't exist in the config file, the categories are displayed as list links on the side.
+`category_display` - An optional setting to define how the category links (i.e. the list of pathogens) are displayed in the rendered page. If this parameter is set to _"dropdown"_, the categories are displayed as a dropdown menu. If the parameter is set to anything else or if the parameter is not included in the config file, the category links are displayed as a list of links on the side.
 
 ### News
 
@@ -225,7 +227,7 @@ The events page consists of a list of upcoming events, including training. To ad
 
 **Tip:** As time progresses, the data file might get very large if no expired events are removed. It may therefore be better to remove expired events from time to time, or when you add a new event.
 
-### New content
+### How to add New content
 
 You can add new content to the node by creating a file (for single pages, e.g. an about page, or contact page) or folder (for a section that contains multiple similar types of pages, e.g. dashboards, news).
 
@@ -303,28 +305,28 @@ You can create a section by creating a folder (and index file within it). Adding
    **Note:** Here, `services` is used instead of `navbar_main` as the `menu` key. In all cases, you should use the `identifier` used for the section index file (see step 1) as the key.
 
 
-### Remove content
+### How to remove default content
 
-The content included in this toolbox are just suggestions, so it is perfectly resonable to hide/remove the suggested default pages or sections. There are two ways to do it as mentioned below.
+Not all of the sections/pages provided in the PPN Toolbox will be relevant for all PPNs. Irrelevant/unwanted sections/pages can either be disabled temporarily or permanently removed by following the instructions below.
 
 #### Disabled temporarily
 
-If you want to not include a page/section temporarily from the website, but you wanna keep the files in the repo for future purpose you can use `ignoreFiles` in the config settings. With this setting you can specify the folder or file name to not include in the built website, below you can find some examples settings.
+If you do not want to display a page/section, but think that you might want to display it later, then you can temporarily disable it. Temporarily disabling the page/section will ensure that the relevant files/code will remain in your repository, making them easy to activate later. In order to temporarily disable a page/section, list it under `ignoreFiles` in the config settings.
 
-- To not include the whole `highlights` section
+-  For example, to disable the `highlights` section:
 
 ```yaml
 ignoreFiles:
    - highlights
 ```
 
-- To not include only demo highlight 2
+- To disable the 'demo highlight 2' page within the highlight section:
 ```yaml
 ignoreFiles:
    - demo2_highlight.md
 ```
 
-- To not include the multiple sections (`news` and `events`) and pages (demo highlight 2)
+- To disable multiple sections (`news` and `events`) and pages (demo highlight 2):
 ```yaml
 ignoreFiles:
    - news
@@ -332,34 +334,34 @@ ignoreFiles:
    - demo2_highlight.md
 ```
 
-#### Delete permenantly
+#### Delete permanently
 
-To remove a default section or page permanatly, the respective folder or file can just be deleted normally.
+To remove a section/page permanently, the respective folder or file can be deleted from the repository.
 
 ## Themes
 
-This repository uses [pathogens portal node theme](https://github.com/ScilifelabDataCentre/node-pathogens-portal-theme). It defines the layout and design for displaying content on the website.
+This repository uses the [pathogens portal node theme](https://github.com/ScilifelabDataCentre/node-pathogens-portal-theme). It defines the layout and design for displaying content on the website.
 
 ### Layout
 
 #### New layout
 
-If you want to create a new layout, create a `layouts` directory and start filling it with your own layouts for each section/page. For example, lets imagine there a content section called _articles_ and to create your own layout you will create a directory `layouts/articles` and in that directory you can have two files
+If you want to create a new layout, create a `layouts` directory and start filling it with your own layouts for each section/page. For example, let's imagine there is a content section called _articles_. To create your own layout for that section, you need to create a directory `layouts/articles`. In that directory, you can have two files:
 
-- `list.html` - file would determine how the `content/articles/_index.md` file is displayed
-- `single.html` - file will determine how the `content/articales/<individual files>.md` files are displayed
+- `list.html` - this file would determine how the `content/articles/_index.md` file is displayed
+- `single.html` - this file would determine how the `content/articles/<individual file name>.md` files are displayed
 
 In order to read more about options with `hugo` layouts, please see the [Hugo documentation](https://gohugo.io/templates/)
 
 #### Edit default
 
-If you want edit/tweak a layout that is included in the PPN theme, you can just copy the respective folders from the theme layout to the project's layout. For example, if you wanna change the _dashboards_ layout included in the theme 
+If you want to edit a layout that is included in the PPN theme, you can copy the respective folders from the theme layout in to the project's layout. For example, if you want to change the _dashboards_ layout included in the PPN theme:
 
 ```
 cp -r themes/node-pathogens-portal-theme/layouts/dashboards layouts/
 ```
 
-**NOTE:** You create your own _dashboards_ layout using the _"new layout"_ approach mentioned above, but copying the layout from theme will save a lot of time if the intended edit is not a minor change. **Also avoid directly modifying the files in themes directory**.
+**NOTE:** You can create your own _dashboards_ layout using the _"new layout"_ approach mentioned above. However, copying the layout from PPN theme will save a lot of time if major changes are needed. **Please avoid directly modifying the files in themes directory**.
 
 ### Update theme
 

--- a/content/datasets/_index.md
+++ b/content/datasets/_index.md
@@ -7,6 +7,6 @@ menu:
     weight: 3
 ---
 
-Data and publications produced by national researchers can be listed/highlighted here. Refer to <a target="_blank" href="https://pathogensportal.ch/access-data/datasets/">Swiss pathogens portal datasets</a> or <a target="_blank" href="https://www.pathogens.se/datasets/all/">Swedish pathogens portal datasets</a>.
+Data produced by national researchers can be listed/highlighted here. Refer to <a target="_blank" href="https://pathogensportal.ch/access-data/datasets/">Swiss pathogens portal datasets</a> or <a target="_blank" href="https://www.pathogens.se/datasets/all/">Swedish pathogens portal datasets</a>.
 
 **Note:** Below it displays query links for Sweden, which was set as node country in config file as an example.

--- a/content/publications/_index.md
+++ b/content/publications/_index.md
@@ -7,6 +7,6 @@ menu:
     weight: 4
 ---
 
-This page lists the publications in Europe PMC with node coutry's affliation and interested query. Read the <a target="_blank" href="https://github.com/ScilifelabDataCentre/node-pathogens-portal?tab=readme-ov-file#publications">guidelines</a> for more information on how to customise.
+This page lists the publications in Europe PMC that involve a researcher affiliated to the relevant nation, and are about particular pathogens. Read the <a target="_blank" href="https://github.com/ScilifelabDataCentre/node-pathogens-portal?tab=readme-ov-file#publications">guidelines</a> for more information on how to customise this query.
 
-**Note:** Below it displays publications with Swedish affliation for example categories set in `publications` section in _Hugo_ config file. Change the `country` and `query_list` as required.
+**Note:** Below displays publications involving researchers affiliated with a Swedish institution for the categories set in the `publications` section in the _Hugo_ config file. Change the `country` and `query_list` as required.

--- a/content/publications/_index.md
+++ b/content/publications/_index.md
@@ -1,0 +1,12 @@
+---
+title: Publications
+menu:
+  navbar_main:
+    name: Publications
+    identifier: publications
+    weight: 4
+---
+
+This page lists the publications in Europe PMC with node coutry's affliation and interested query. Read the <a target="_blank" href="https://github.com/ScilifelabDataCentre/node-pathogens-portal?tab=readme-ov-file#publications">guidelines</a> for more information on how to customise.
+
+**Note:** Below it displays publications with Swedish affliation for example categories set in `publications` section in _Hugo_ config file. Change the `country` and `query_list` as required.

--- a/content/topics/_index.md
+++ b/content/topics/_index.md
@@ -4,7 +4,7 @@ menu:
   navbar_main:
     name: Topics
     identifier: topics
-    weight: 4
+    weight: 5
     params:
       type: dropdown
       include_parent: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -33,6 +33,15 @@ params:
     contact_email: "mail@example.com"
   # Url to github repository, node should keep the URL of their fork
   git_repository: "https://github.com/ScilifelabDataCentre/node-pathogens-portal"
+  # Publications related configuration
+  publications:
+    country: "Sweden"
+    # It is important to use "" (double quotes) within the query string
+    query_list:
+      covid-19: 'ABSTRACT:("sars-cov-2" OR "covid-19")'
+      influenza: 'ABSTRACT:"influenza"'
+    # Optional setting
+    category_display: "list"
 
 taxonomies:
   highlights_topic: highlights_topics
@@ -56,4 +65,3 @@ related:
       weight: 100
       threshold: 80
       toLower: false
-


### PR DESCRIPTION
In this PR we add a `publications` section, which will pull 10 recent publications for query list specified in the config file.

The `README` instructions are also update accordingly, see [here](https://github.com/ScilifelabDataCentre/node-pathogens-portal/blob/add_publications/README.md) to view rendered readme.